### PR TITLE
redownload keys after cache expires

### DIFF
--- a/pyjwt_key_fetcher/http_client.py
+++ b/pyjwt_key_fetcher/http_client.py
@@ -2,6 +2,7 @@ import abc
 from json import JSONDecodeError
 from typing import Any, Dict
 
+import aiocache
 import aiohttp
 
 from pyjwt_key_fetcher.errors import JWTHTTPFetchError
@@ -33,9 +34,12 @@ class DefaultHTTPClient(HTTPClient):
     def __init__(self):
         self.session = aiohttp.ClientSession()
 
+    @aiocache.cached(ttl=300)
     async def get_json(self, url: str) -> Dict[str, Any]:
         """
         Get and parse JSON data from a URL.
+
+        Rate limited to once per 5 minutes (300 seconds).
 
         :param url: The URL to fetch the data from.
         :return: The JSON data as a dictionary.


### PR DESCRIPTION
I did some testing and thanks to some dicts in the OpenIDProvider, we would never go back to fetch the JWKs even after the 5 minutes of cache expired.

An example is

https://github.com/ioxiocom/pyjwt-key-fetcher/blob/93e5055d5860dc8b2739985b53ed4929a17581c5/pyjwt_key_fetcher/openid_provider.py#L97-L99

And also

https://github.com/ioxiocom/pyjwt-key-fetcher/blob/93e5055d5860dc8b2739985b53ed4929a17581c5/pyjwt_key_fetcher/openid_provider.py#L80-L83

*****

Also, since the cache was set on a function with no arguments

https://github.com/ioxiocom/pyjwt-key-fetcher/blob/main/pyjwt_key_fetcher/openid_provider.py#L48-L49

I think it would cache even if the `self` object had mutated. So I moved it to `DefaultHTTPClient` where there is little state to mutate.

*****

Does this make sense to the objective of the library? Or was the idea to fetch after 5 minutes ONLY if the key was not known already? I am not sure if a key can maintain id but change the contents.

