### PR TITLE
Add support for static JWKS URIs

### DIFF
--- a/pyjwt_key_fetcher/__init__.py
+++ b/pyjwt_key_fetcher/__init__.py
@@ -2,3 +2,4 @@
 from pyjwt_key_fetcher.fetcher import AsyncKeyFetcher
 from pyjwt_key_fetcher.http_client import DefaultHTTPClient
 from pyjwt_key_fetcher.key import Key
+from pyjwt_key_fetcher.provider import OpenIDConfigurationTypeDef

--- a/pyjwt_key_fetcher/tests/test_fetcher.py
+++ b/pyjwt_key_fetcher/tests/test_fetcher.py
@@ -115,3 +115,16 @@ async def test_issuer_validation(create_provider_fetcher_and_client, create_prov
 
     assert client.get_configuration.call_count == 1
     assert client.get_jwks.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_static_issuer_config():
+    issuer = "https://valid.example.com"
+
+    fetcher = pyjwt_key_fetcher.AsyncKeyFetcher(
+        static_issuer_config={issuer: {"jwks_uri": f"{issuer}/.well-known/jwks.json"}}
+    )
+    provider = fetcher._get_provider(issuer)
+
+    provider_config = await provider.get_configuration()
+    assert provider_config == {"jwks_uri": f"{issuer}/.well-known/jwks.json"}


### PR DESCRIPTION
This project is by far the best we've found for validating against a JWKS. However, the hard requirement to perform an `openid-configuration` lookup to determine the JWKS URI is problematic for use cases that don't implement that file. Our previous solution involved monkey patching the `Provider`, but it would be much nicer to have a native setting for this.