### PR TITLE
fix(DefaultHTTPClient): Stops potential unclosed connections

### DIFF
--- a/pyjwt_key_fetcher/http_client.py
+++ b/pyjwt_key_fetcher/http_client.py
@@ -30,9 +30,6 @@ class DefaultHTTPClient(HTTPClient):
     A default client implemented using aiohttp.
     """
 
-    def __init__(self) -> None:
-        self.session = aiohttp.ClientSession()
-
     async def get_json(self, url: str) -> Dict[str, Any]:
         """
         Get and parse JSON data from a URL.
@@ -45,10 +42,11 @@ class DefaultHTTPClient(HTTPClient):
             raise JWTHTTPFetchError("Unsupported protocol in 'iss'")
 
         try:
-            async with self.session.get(url) as resp:
-                data: Dict[str, Any] = await resp.json()
-                if resp.status != 200:
-                    raise JWTHTTPFetchError(f"Failed to fetch or decode {url}")
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url) as resp:
+                    data: Dict[str, Any] = await resp.json()
+                    if resp.status != 200:
+                        raise JWTHTTPFetchError(f"Failed to fetch or decode {url}")
         except (aiohttp.ClientError, JSONDecodeError) as e:
             raise JWTHTTPFetchError(f"Failed to fetch or decode {url}") from e
 


### PR DESCRIPTION
If the `DefaultHTTPClient` is initialised but, for some reason, `get_json` is never called this will result in unclosed connections. Depending on the environment, after the pool is exhausted, this can result in an error.

An example of this error we were seeing in production was:

`Unclosed connector\nconnections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x7b7796713cb0>, 488429.373)]']\nconnector: <aiohttp.connector.TCPConnector object at 0x7b7795a2f1d0>`

In our instance this was happening as an instance of `AsyncKeyFetcher` was being initialised but a subsequent error meant execution was aborted before `get_json` was called, meaning the connection opened on class initialisation was never closed.

This PR marginally reduces the class footprint and ensures the scope of the opened connection is reduced to a minimum.